### PR TITLE
Use CSS classes for styling

### DIFF
--- a/src/main/resources/hudson/plugins/summary_report/ACIPluginBuildAction/componentField.jelly
+++ b/src/main/resources/hudson/plugins/summary_report/ACIPluginBuildAction/componentField.jelly
@@ -1,9 +1,19 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
     <j:set var="phref" value="${b.href}"/>
     <j:if test="${b.href != null}" >
-        <j:set var="phref" value="${buildn}${b.href}"/>
+        <div class="summary_report_field" style="color:${b.titleColor};">
+            <span>${b.fieldName}</span>
+            <span style="color:${b.detailColor};"><a href="${buildn}${b.href}">${b.fieldValue}</a></span>
+        </div>
     </j:if>
-    <p style="color:${b.titleColor};"><b>${b.fieldName}: </b><a style="color:${b.detailColor};" href="${phref}">${b.fieldValue}</a></p>
+
+    <j:if test="${b.href == null}" >
+        <div class="summary_report_field" style="color:${b.titleColor};">
+            <span>${b.fieldName}</span>
+            <span style="color:${b.detailColor};">${b.fieldValue}</span>
+        </div>
+    </j:if>
+
     <pre>${b.cdata}</pre>
 </j:jelly>
 

--- a/src/main/resources/hudson/plugins/summary_report/ACIPluginBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/summary_report/ACIPluginBuildAction/summary.jelly
@@ -12,6 +12,8 @@ xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
    <!-- Css -->
     <link type="text/css" href="${rootURL}/plugin/summary_report/lib/jquery/css/smoothness/jquery-ui-1.8.6.custom.css" rel="stylesheet" />
 
+    <link type="text/css" href="${rootURL}/plugin/summary_report/css/summary_report.css" rel="stylesheet" />
+
     <!-- JQuery lib -->
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/jquery/js/jquery-1.4.2.min.js"></script>
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/jquery/js/jquery-ui-1.8.6.custom.min.js"></script>
@@ -25,11 +27,12 @@ xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
     <!--     Main        -->
     <!-- *************** -->
     
-    <table>
-        <tr>
-            <td>
+    <tr>
+        <td colspan="3">
+            <div class="summary_report_build">
                 <j:set var="projectname" value="${from.getProjectName()}"/>
                 <j:set var="buildnumber" value="${from.getBuildNumber()}"/>
+
                 
                 <!-- For each file .xml-->
                 <j:forEach var="a" items="${it.report.section}" indexVar="indexA">
@@ -68,8 +71,8 @@ xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
                 <j:forEach var="c" items="${from.getFileError()}" indexVar="indexC">
                     <h2 style="color:${c[0]};">${c[1]}: <a style="color:${c[2]};" href="${c[4]}">${c[5]}</a></h2>
                 </j:forEach>
-            </td>
-        </tr>
-    </table>
+            </div>
+        </td>
+    </tr>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/summary_report/ACIPluginProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/summary_report/ACIPluginProjectAction/floatingBox.jelly
@@ -6,58 +6,52 @@ xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
     <!-- <st:include page="/style/buildSummaryCss.jelly" /> -->
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/sorttable/sorttable.js"></script>
     <link type="text/css" href="${rootURL}/plugin/summary_report/lib/jquery/css/smoothness/jquery-ui-1.8.6.custom.css" rel="stylesheet" />
+    <link type="text/css" href="${rootURL}/plugin/summary_report/css/summary_report.css" rel="stylesheet" />
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/jquery/js/jquery-1.4.2.min.js"></script>
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/jquery/js/jquery-ui-1.8.6.custom.min.js"></script>
     <script type="text/javascript" src="${rootURL}/plugin/summary_report/lib/jquery.cookie.js"></script>
     
-    <div align="right">
-    <table>
-        <tr>
-            <h1 align="center">Result of build #${from.getLastFinishedBuild().getNumber()}</h1>
-        </tr>
-        <tr>
-            <td>
-            <j:set var="buildn" value="${from.getLastFinishedBuild().getNumber()}/"/>
-            <j:set var="projectname" value="${from.getProjectName()}"/>
-            <j:set var="buildnumber" value="${from.getLastFinishedBuild().getNumber()}"/>
+    <div class="summary_report_project">
+        <h1>Result of build #${from.getLastFinishedBuild().getNumber()}</h1>
 
-                <!-- For each file .xml-->
-                <j:forEach var="a" items="${from.getReport().getSection()}" indexVar="indexA">
+        <j:set var="buildn" value="${from.getLastFinishedBuild().getNumber()}/"/>
+        <j:set var="projectname" value="${from.getProjectName()}"/>
+        <j:set var="buildnumber" value="${from.getLastFinishedBuild().getNumber()}"/>
 
-                    <h2 style="color:${a.fontColor};">${a.sectionName}</h2>
+        <!-- For each file .xml-->
+        <j:forEach var="a" items="${from.getReport().getSection()}" indexVar="indexA">
 
-                    <!-- For each object in the section -->
-                    <j:forEach var="b" items="${a.objectList}" indexVar="indexB">
+            <h2 style="color:${a.fontColor};">${a.sectionName}</h2>
 
-                        <!-- If the object is a table -->
-                        <j:if test="${b.status == 'table'}">
-                            <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentTable.jelly" />
-                        </j:if>
+            <!-- For each object in the section -->
+            <j:forEach var="b" items="${a.objectList}" indexVar="indexB">
 
-                        <!-- If the object is a field -->
-                        <j:if test="${b.status == 'field'}">
-                            <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentField.jelly" />
-                        </j:if>
+                <!-- If the object is a table -->
+                <j:if test="${b.status == 'table'}">
+                    <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentTable.jelly" />
+                </j:if>
 
-                        <!-- If the object is an accordion -->
-                        <j:if test="${b.status == 'accordion'}">
-                            <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentAccordion.jelly" />
-                        </j:if>
+                <!-- If the object is a field -->
+                <j:if test="${b.status == 'field'}">
+                    <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentField.jelly" />
+                </j:if>
 
-                         <!-- If the object is a tab -->
-                        <j:if test="${b.status == 'tabs'}">
-                            <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentTabs.jelly" />
-                        </j:if>
+                <!-- If the object is an accordion -->
+                <j:if test="${b.status == 'accordion'}">
+                    <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentAccordion.jelly" />
+                </j:if>
 
-                    </j:forEach>
+                 <!-- If the object is a tab -->
+                <j:if test="${b.status == 'tabs'}">
+                    <st:include class="hudson.plugins.summary_report.ACIPluginBuildAction" page="componentTabs.jelly" />
+                </j:if>
 
-                </j:forEach>
-                <!-- For each fileError-->
-                <j:forEach var="c" items="${from.getFileError()}" indexVar="indexC">
-                    <h2 style="color:${c[0]};">${c[1]}: <a style="color:${c[2]};" href="${c[3]}">${c[5]}</a></h2>
-                </j:forEach>
-            </td>
-        </tr>
-    </table>
-</div>
+            </j:forEach>
+
+        </j:forEach>
+        <!-- For each fileError-->
+        <j:forEach var="c" items="${from.getFileError()}" indexVar="indexC">
+            <h2 style="color:${c[0]};">${c[1]}: <a style="color:${c[2]};" href="${c[3]}">${c[5]}</a></h2>
+        </j:forEach>
+    </div>
 </j:jelly>

--- a/src/main/webapp/css/summary_report.css
+++ b/src/main/webapp/css/summary_report.css
@@ -1,0 +1,21 @@
+.summary_report_project h1 {
+    text-align: center;
+}
+
+.summary_report_project {
+    margin-right: 2em;
+    margin-top: 5em;
+}
+
+.summary_report_field {
+    margin-top: 1em;
+}
+
+.summary_report_field span:first-child {
+    font-weight: bold;
+    padding-right: 0.7em;
+}
+
+.summary_report_field span:first-child:after {
+    content: ":";
+}


### PR DESCRIPTION
This makes it possible to re-style the information with a custom
stylesheet.

I wanted to adjust the look of the output from the summary_report plugin with a custom stylesheet, bot realized that it wasn't possible since the generated html-code did not specify any css-classes. The patch changes the generated html-code for both the build and project pages, but only for "fields", not tables, accordions or any other types of output. The patch also includes css-rules that make sure that the output is rendered in the same way as the old output.
