### PR TITLE
Feature/show on project page

### DIFF
--- a/src/main/java/hudson/plugins/summary_report/ACIPluginProjectAction.java
+++ b/src/main/java/hudson/plugins/summary_report/ACIPluginProjectAction.java
@@ -27,6 +27,9 @@ import hudson.model.Action;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.plugins.summary_report.report.Report;
+import hudson.util.DescribableList;
+import hudson.tasks.Publisher;
+import hudson.model.Descriptor;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -162,4 +165,16 @@ public class ACIPluginProjectAction implements Action, Serializable {
         str = str.replace(".", "dot");
         return str;
     }
+
+    /**
+     * This method return a boolean indicating whether to display the report on the project page
+     *
+     * @return shownOnProjectPage
+     *                 The project name
+     */
+     public boolean isShownOnProjectPage() {
+       DescribableList<Publisher, Descriptor<Publisher>> publishers = project.getPublishersList();
+       ACIPluginPublisher publisher = publishers.get(ACIPluginPublisher.class);
+       return publisher.isShownOnProjectPage();
+     }
 }

--- a/src/main/java/hudson/plugins/summary_report/ACIPluginProjectAction.java
+++ b/src/main/java/hudson/plugins/summary_report/ACIPluginProjectAction.java
@@ -125,8 +125,12 @@ public class ACIPluginProjectAction implements Action, Serializable {
      */
     public Report getReport() {
        AbstractBuild<?, ?> build = getLastFinishedBuild();
+       // When the project has not had a build yet, build is null
+       if (build == null) {
+           return null;
+       }
        ACIPluginBuildAction resultAction =
-    		   build.getAction(ACIPluginBuildAction.class);
+           build.getAction(ACIPluginBuildAction.class);
        return resultAction.getReport();
     }
 
@@ -138,8 +142,12 @@ public class ACIPluginProjectAction implements Action, Serializable {
      */
     public ArrayList< ArrayList<String> > getFileError() {
         AbstractBuild<?, ?> build = getLastFinishedBuild();
+        // When the project has not had a build yet, build is null
+        if (build == null) {
+            return null;
+        }
         ACIPluginBuildAction resultAction =
-        		build.getAction(ACIPluginBuildAction.class);
+            build.getAction(ACIPluginBuildAction.class);
         return resultAction.getFileError();
     }
 

--- a/src/main/java/hudson/plugins/summary_report/ACIPluginPublisher.java
+++ b/src/main/java/hudson/plugins/summary_report/ACIPluginPublisher.java
@@ -41,6 +41,7 @@ import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.Project;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.xml.sax.SAXException;
 
 /**
@@ -54,13 +55,22 @@ public class ACIPluginPublisher extends Recorder {
 	private String name;
 
 	/**
+        * Whether the reports are shown on the project page or not.
+        * By default, the reports are shown on the project page as
+        * well as on the results page. When the reports are very long
+        * the user can chose to display them only on the results page.
+        */
+       private boolean shownOnProjectPage = true;
+
+       /**
 	 * Set the name of the publisher.
 	 * @param name
 	 * 		The name of the published report
 	 */
 	@DataBoundConstructor
-	public ACIPluginPublisher(final String name) {
+       public ACIPluginPublisher(final String name, final boolean shownOnProjectPage) {
 		this.name = name;
+               this.shownOnProjectPage = shownOnProjectPage;
 	}
 
 	/**
@@ -73,6 +83,15 @@ public class ACIPluginPublisher extends Recorder {
 	}
 
 	/**
+        * Get whether or not to display the report on the Project page.
+        * @return boolean
+        *      Whether or not to display the report on the Project page
+        */
+       public boolean isShownOnProjectPage() {
+               return shownOnProjectPage;
+       }
+
+       /**
 	 * Get the action associated to the publisher.
 	 * @param project
 	 * 		Project on which to apply publication

--- a/src/main/resources/hudson/plugins/summary_report/ACIPluginProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/summary_report/ACIPluginProjectAction/floatingBox.jelly
@@ -3,6 +3,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
 xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
 
+  <j:if test="${from.isShownOnProjectPage() == true}" >
 
     <!-- Import library -->
     <!-- <st:include page="/style/buildSummaryCss.jelly" /> -->
@@ -62,4 +63,5 @@ xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hu
             </j:forEach>
         </j:if>
     </div>
+  </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/summary_report/ACIPluginPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/summary_report/ACIPluginPublisher/config.jelly
@@ -9,4 +9,11 @@
 			description="ex : artifacts/log/*.xml">
 			<f:textbox field="name" />
 		</f:entry>
+                <f:entry
+                       title="Show on Project Page"
+                       field="shownOnProjectPage"
+                       description="By default, the reports are shown on the Project Page and on the Results Page. Unselect to display only on the Results Page."
+                       >
+                       <f:checkbox />
+               </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/plugins/summary_report/ACIPluginPublisherTest.java
+++ b/src/test/java/hudson/plugins/summary_report/ACIPluginPublisherTest.java
@@ -61,7 +61,7 @@ public class ACIPluginPublisherTest  extends HudsonTestCase{
         project.getPublishersList().add(archiver);
         
         /* Add ACIPluginPublisher publisher */
-        ACIPluginPublisher publisher = new ACIPluginPublisher("*.xml");
+        ACIPluginPublisher publisher = new ACIPluginPublisher("*.xml", true);
         project.getPublishersList().add(publisher);
 
         /* After add ACIPluginPublisher and ArtifactArchiver */


### PR DESCRIPTION
Hi,

I created a patch to solve one problem and to add one feature:
- Empty projects without builds used to cause errors because there is no report to display, so I fixed that
- I need the ability to disable the displaying of reports on the project page and only show reports on the build pages, so I added that

I hope you can accept these changes.

Thanks.
